### PR TITLE
Exclude "git+"... requirements from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[r for r in open("requirements.txt").read().split("\n")
         if not r.startswith("git+")],
-    dependency_links=[r for r in open("requirements.txt").read().split("\n")
-        if r.startswith("git+")],
     keywords=["OCR", "optical character recognition", "ocropy", "ocropus", "kraken"],
     data_files=[("", ["requirements.txt"] + resources)],
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
     python_requires=">=3.7",
     install_requires=[r for r in open("requirements.txt").read().split("\n")
         if not r.startswith("git+")],
+    dependency_links=[r for r in open("requirements.txt").read().split("\n")
+        if r.startswith("git+")],
     keywords=["OCR", "optical character recognition", "ocropy", "ocropus", "kraken"],
     data_files=[("", ["requirements.txt"] + resources)],
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
         ],
     },
     python_requires=">=3.7",
-    install_requires=open("requirements.txt").read().split("\n"),
+    install_requires=[r for r in open("requirements.txt").read().split("\n")
+        if not r.startswith("git+")],
     keywords=["OCR", "optical character recognition", "ocropy", "ocropus", "kraken"],
     data_files=[("", ["requirements.txt"] + resources)],
 )


### PR DESCRIPTION
Leaving setup.py as-is results in this error:

```
× Getting requirements to build wheel did not run successfully.                                                                                                                              
  │ exit code: 1                                                                                                                                                                               
  ╰─> [5 lines of output]                                                                                                                                                                      
      /usr/local/lib/python3.7/dist-packages/setuptools/dist.py:694: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscor
e name 'description_file' instead                                                                                                                                                              
        % (opt, underscore_opt))                                                                                                                                                               
      /usr/local/lib/python3.7/dist-packages/setuptools/dist.py:694: UserWarning: Usage of dash-separated 'licence-file' will not be supported in future versions. Please use the underscore na
me 'licence_file' instead                                                                                                                                                                      
        % (opt, underscore_opt))                                                                                                                                                               
      error in calamari_ocr setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'+https:/'": Expecte
d stringEnd                                                                                                                                                                                    
      [end of output]                                                                                                                                                                          
                                                                                                                                                                                               
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```

Since nobody is installing this particular fork of calamari with pip, it is safe to exclude certain requirements from the `install_requires` list.